### PR TITLE
RFC-0001: Inherit from eslint-config-airbnb and extend

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+# editorconfig-tools is unable to ignore longs strings or urls
+max_line_length = null

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "./index.js"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Set Git ignored files/folders
+
+node_modules
+
+# Let lock files for apps
+yarn.lock
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -1,0 +1,13 @@
+module.exports = {
+  extends: [
+    'eslint-config-airbnb'
+  ].map(require.resolve),
+  rules: {
+    'comma-dangle': 'off',
+    'padding-line-between-statements': ['error', {
+      blankLine: 'always',
+      prev: ['const', 'let'],
+      next: 'return'
+    }]
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "eslint-config-beetech",
+  "version": "0.1.0",
+  "description": "Official lint config from Beetech.global",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/BeeTech-global/eslint-config-beetech.git"
+  },
+  "keywords": [
+    "eslint"
+  ],
+  "author": "BeeTech <it@beetech.global>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/BeeTech-global/eslint-config-beetech/issues"
+  },
+  "homepage": "https://github.com/BeeTech-global/eslint-config-beetech#readme"
+}

--- a/package.json
+++ b/package.json
@@ -18,5 +18,14 @@
   "bugs": {
     "url": "https://github.com/BeeTech-global/eslint-config-beetech/issues"
   },
-  "homepage": "https://github.com/BeeTech-global/eslint-config-beetech#readme"
+  "homepage": "https://github.com/BeeTech-global/eslint-config-beetech#readme",
+  "dependencies": {
+    "eslint-config-airbnb": "^16.1.0",
+    "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-jsx-a11y": "^6.0.3",
+    "eslint-plugin-react": "^7.6.1"
+  },
+  "devDependencies": {
+    "eslint": "^4.16.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Official lint config from Beetech.global",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "eslint test/sample-file-001.js"
   },
   "repository": {
     "type": "git",
@@ -14,6 +14,9 @@
     "eslint"
   ],
   "author": "BeeTech <it@beetech.global>",
+  "contributors": [
+    "Lourenzo Ferreira <lourenzo@gmail.com>"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/BeeTech-global/eslint-config-beetech/issues"

--- a/test/sample-file-001.js
+++ b/test/sample-file-001.js
@@ -1,0 +1,14 @@
+function someOperation() {
+  return 1;
+}
+
+const a = (x) => {
+  const y = x + 1;
+
+  return y;
+};
+
+module.exports = {
+  a,
+  someOperation
+};


### PR DESCRIPTION
For now, its only extending airbnb's config, setting comma-dangle off, and adding a rule that requires a new line before return and after variable declarations.
Note, since [`newline-before-return`](https://eslint.org/docs/rules/newline-before-return) is being deprecated, the rule was replaced with it's successor: [`padding-line-between-statements`](https://eslint.org/docs/rules/padding-line-between-statements).

The settings used for `padding-line-between-statements` were:

```js
'padding-line-between-statements': ['error', {
  blankLine: 'always',
  prev: ['const', 'let'], // Note: We can add more statements here
  next: 'return'
}]
```
